### PR TITLE
1.8.1: code-review follow-ups (load-facts/rebuild hardening) + verified CLI import docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 This changelog documents all the different updates that occur for this framework.
 
-## [1.8.0] - 2026-07-22
+## [1.8.1] - 2026-07-23
+
+Robustness follow-ups to the 1.8.0 code review — no functional changes to what the commands do on the happy path.
+
+### Fixed
+
+- **`mdb load-facts` hardening.** CAS URL path segments (server, caslib, table) are now URL-encoded, so a caslib name with a space no longer produces a malformed request. An unload failure that is not "nothing loaded" (e.g. a 403 permission error) now raises immediately with a clear message instead of surfacing later as an opaque `LOADTABLE_EXISTS` conflict on the upload. When neither fact sheet exists the command exits non-zero instead of silently succeeding, and the per-table message no longer claims "created" when only the loaded copy was absent
+- **CLI consistency.** `--prune` without `--rebuild` is now an error (both `mdb sync` and `mdb load-facts`) instead of being silently ignored, and `mdb load-facts --rebuild` gained the same `--prune` option `mdb sync --rebuild` has. The duplicated rebuild loop is factored into one shared helper
+- **`rebuild_sheet` rejects a mixed llm/embedding manifest list** instead of silently rendering one kind against the other kind's columns (the CLI never did this; the guard protects future callers)
+
+### Changed
+
+- **Transfer-package import docs use the current CLI form and a verified mapping workflow.** The import guides now use `sas-viya transfer packages upload` / `import` (the plugin marks the old `transfer upload` / `import` as deprecated aliases, noted for older versions), and the mapping-file alternative is documented as validated live: `upload --mapping mapping.json` writes the file with the `VisualElement:ve9` substitution to edit, which `import --mapping` then applies (`transfer get-mapping` regenerates it)
+
+## [1.8.0] - 2026-07-23
 
 An admin migration guide for the move from the retired standalone Python scripts to the Model Definition Builder (`mdb`), and a skill to find registered models that predate the 1.6.0 attribute/lifecycle improvements.
 

--- a/Model-Definition-Builder/cli/src/mdb/cli.py
+++ b/Model-Definition-Builder/cli/src/mdb/cli.py
@@ -75,6 +75,13 @@ class Context:
             )
         return folders
 
+    def managed_manifests(self, kind: str) -> list[ModelManifest]:
+        return [
+            load_manifest(f)
+            for f in sorted(self.defs_dir(kind).iterdir())
+            if f.is_dir() and (f / MANIFEST_FILENAME).is_file()
+        ]
+
     def find_folder(self, model_id: str) -> Path | None:
         for kind in KINDS:
             folder = self.defs_dir(kind) / model_id
@@ -450,6 +457,28 @@ def validate(
     raise typer.Exit(1 if has_error else 0)
 
 
+def _rebuild_sheets(ctx: Context, prune: bool = False) -> bool:
+    """Regenerate each kind's fact sheet from its managed definitions (shared by
+    `sync --rebuild` and `load-facts --rebuild`). Returns False when there are no
+    managed definitions at all."""
+    rebuilt_any = False
+    for kind in KINDS:
+        manifests = ctx.managed_manifests(kind)
+        if not manifests:
+            continue
+        rebuilt_any = True
+        sheet = ctx.fact_sheet(kind)
+        summary = facts.rebuild_sheet(sheet, manifests, keep_legacy=not prune)
+        verb = "created" if summary["created"] else "rebuilt"
+        message = f"{sheet.name}: {verb} from {summary['written']} definition(s)"
+        if summary["legacy_kept"]:
+            message += f", kept {summary['legacy_kept']} legacy row(s)"
+        if summary["legacy_dropped"]:
+            message += f", dropped {summary['legacy_dropped']} legacy row(s)"
+        console.print(message)
+    return rebuilt_any
+
+
 @app.command()
 def sync(
     ids: Optional[list[str]] = typer.Argument(None),
@@ -472,29 +501,13 @@ def sync(
     longer maintain the CSV by hand alongside the definitions.
     """
     ctx = Context()
+    if prune and not rebuild:
+        console.print("[red]--prune only applies together with --rebuild.[/red]")
+        raise typer.Exit(2)
     if rebuild:
         if ids or all_:
             console.print("[yellow]--rebuild regenerates the entire sheet for each kind; ignoring model ids / --all.[/yellow]")
-        rebuilt_any = False
-        for kind in KINDS:
-            manifests = [
-                load_manifest(f)
-                for f in sorted(ctx.defs_dir(kind).iterdir())
-                if f.is_dir() and (f / MANIFEST_FILENAME).is_file()
-            ]
-            if not manifests:
-                continue
-            rebuilt_any = True
-            sheet = ctx.fact_sheet(kind)
-            summary = facts.rebuild_sheet(sheet, manifests, keep_legacy=not prune)
-            verb = "created" if summary["created"] else "rebuilt"
-            message = f"{sheet.name}: {verb} from {summary['written']} definition(s)"
-            if summary["legacy_kept"]:
-                message += f", kept {summary['legacy_kept']} legacy row(s)"
-            if summary["legacy_dropped"]:
-                message += f", dropped {summary['legacy_dropped']} legacy row(s)"
-            console.print(message)
-        if not rebuilt_any:
+        if not _rebuild_sheets(ctx, prune=prune):
             console.print("[yellow]No managed definitions found (no folder has a definition.yaml yet).[/yellow]")
         return
     for folder in ctx.resolve_targets(ids or [], all_):
@@ -519,6 +532,11 @@ def load_facts(
         False, "--rebuild",
         help="Regenerate the sheets from the definitions before loading.",
     ),
+    prune: bool = typer.Option(
+        False, "--prune",
+        help="With --rebuild, also drop rows for models that no longer have a "
+             "definition folder (default keeps such legacy rows).",
+    ),
 ):
     """Upload, promote and save the fact-sheet CSVs to CAS (drops any existing table first).
 
@@ -529,15 +547,11 @@ def load_facts(
     """
     from .viya.cas import load_fact_sheet, resolve_server
     ctx = Context()
+    if prune and not rebuild:
+        console.print("[red]--prune only applies together with --rebuild.[/red]")
+        raise typer.Exit(2)
     if rebuild:
-        for kind in KINDS:
-            manifests = [
-                load_manifest(f)
-                for f in sorted(ctx.defs_dir(kind).iterdir())
-                if f.is_dir() and (f / MANIFEST_FILENAME).is_file()
-            ]
-            if manifests:
-                facts.rebuild_sheet(ctx.fact_sheet(kind), manifests)
+        _rebuild_sheets(ctx, prune=prune)
     caslib = caslib or os.environ.get("SAS_CAS_LIBRARY") or "Public"
     server_choice = server or os.environ.get("SAS_CAS_SERVER")
     with _viya_session() as session:
@@ -557,10 +571,13 @@ def load_facts(
                 console.print(f"  [red]{exc}[/red]")
                 raise typer.Exit(1)
             loaded += 1
-            action = "replaced existing" if result["dropped"] else "created"
-            console.print(f"  {result['table']}: {action} - uploaded, promoted (global) and saved to disk")
-    if loaded:
-        console.print("[green]Done. The tables are promoted and persisted; the monitoring report can bind to them.[/green]")
+            # "dropped" reflects the loaded copy; the save step replaces any saved one
+            suffix = " (replaced a loaded copy)" if result["dropped"] else ""
+            console.print(f"  {result['table']}: uploaded, promoted (global) and saved to disk{suffix}")
+    if not loaded:
+        console.print("[red]No fact sheet was loaded - generate them first with 'mdb sync --rebuild'.[/red]")
+        raise typer.Exit(1)
+    console.print("[green]Done. The tables are promoted and persisted; the monitoring report can bind to them.[/green]")
 
 
 # ---------------------------------------------------------------------------

--- a/Model-Definition-Builder/cli/src/mdb/core/facts.py
+++ b/Model-Definition-Builder/cli/src/mdb/core/facts.py
@@ -221,6 +221,10 @@ def rebuild_sheet(
     """
     if not manifests:
         raise ValueError("rebuild_sheet requires at least one manifest")
+    kinds = {m.kind for m in manifests}
+    if len(kinds) != 1:
+        # A mixed list would silently render one kind against the other's columns
+        raise ValueError(f"rebuild_sheet requires manifests of a single kind, got: {sorted(kinds)}")
     kind = manifests[0].kind
     header = ",".join(COLUMNS_BY_KIND[kind])
     managed_ids = {m.model_id for m in manifests}

--- a/Model-Definition-Builder/cli/src/mdb/viya/cas.py
+++ b/Model-Definition-Builder/cli/src/mdb/viya/cas.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from urllib.parse import quote
 
 DEFAULT_SERVER = "cas-shared-default"
 DEFAULT_CASLIB = "Public"
@@ -38,7 +39,8 @@ def resolve_server(session, server: str | None) -> str:
 
 
 def _base(server: str, caslib: str) -> str:
-    return f"/casManagement/servers/{server}/caslibs/{caslib}/tables"
+    # Encode each path segment - a caslib like "My Lib" must not break the URL
+    return f"/casManagement/servers/{quote(server, safe='')}/caslibs/{quote(caslib, safe='')}/tables"
 
 
 def _drop_table(session, server: str, caslib: str, table: str) -> bool:
@@ -46,9 +48,17 @@ def _drop_table(session, server: str, caslib: str, table: str) -> bool:
     "table already exists" (LOADTABLE_EXISTS) conflict. The saved source on disk,
     if any, is overwritten by the later save-with-replace - so a plain unload is
     the right "drop". Returns True if a loaded table was unloaded, False if there
-    was nothing loaded (a 404 from state update is not an error)."""
-    response = session.put(f"{_base(server, caslib)}/{table}/state?value=unloaded")
-    return response.status_code < 300
+    was nothing loaded (404). Anything else (e.g. a 403 permission failure) raises
+    here, where the cause is clear, instead of surfacing later as an opaque
+    LOADTABLE_EXISTS conflict on the upload."""
+    response = session.put(f"{_base(server, caslib)}/{quote(table, safe='')}/state?value=unloaded")
+    if response.status_code < 300:
+        return True
+    if response.status_code == 404:
+        return False
+    raise RuntimeError(
+        f"Unloading {table} failed: HTTP {response.status_code} {response.text[:300]}"
+    )
 
 
 def _upload_table(session, server: str, caslib: str, table: str, csv_path: Path) -> None:
@@ -72,9 +82,11 @@ def _upload_table(session, server: str, caslib: str, table: str, csv_path: Path)
 
 
 def _save_table(session, server: str, caslib: str, table: str) -> None:
-    """Persist the loaded table to the caslib's data source on disk (replace)."""
+    """Persist the loaded table to the caslib's data source (replace). The
+    sashdat format assumes a path-based caslib (like Public); a database-backed
+    caslib would reject it - target a path caslib for the fact sheets."""
     response = session.post(
-        f"{_base(server, caslib)}/{table}",
+        f"{_base(server, caslib)}/{quote(table, safe='')}",
         data=json.dumps({"replace": True, "format": "sashdat"}),
         headers={
             "Content-Type": "application/vnd.sas.cas.table.save.request+json",

--- a/Model-Definition-Builder/cli/tests/test_cas.py
+++ b/Model-Definition-Builder/cli/tests/test_cas.py
@@ -24,10 +24,11 @@ class FakeResponse:
 
 
 class FakeSession:
-    def __init__(self, servers=None, upload_status=201):
+    def __init__(self, servers=None, upload_status=201, unload_status=200):
         self.calls = []
         self._servers = servers if servers is not None else [{"name": "cas-shared-default"}]
         self._upload_status = upload_status
+        self._unload_status = unload_status
 
     def get(self, path, **kw):
         self.calls.append(("GET", path, kw))
@@ -37,7 +38,7 @@ class FakeSession:
 
     def put(self, path, **kw):
         self.calls.append(("PUT", path, kw))
-        return FakeResponse(200)
+        return FakeResponse(self._unload_status)
 
     def post(self, path, **kw):
         self.calls.append(("POST", path, kw))
@@ -45,10 +46,6 @@ class FakeSession:
         if path.endswith("/tables"):
             return FakeResponse(self._upload_status, {"name": "T"})
         return FakeResponse(200, {})
-
-    def delete(self, path, **kw):
-        self.calls.append(("DELETE", path, kw))
-        return FakeResponse(204)
 
 
 def _csv(tmp_path):
@@ -99,3 +96,24 @@ def test_embedding_table_name_and_upload_failure(tmp_path):
     session = FakeSession(upload_status=409)
     with pytest.raises(RuntimeError, match="Uploading EMBEDDING_FACT_SHEET"):
         cas.load_fact_sheet(session, _csv(tmp_path), "embedding", "Public", "cas-shared-default")
+
+
+def test_unload_404_means_nothing_loaded_but_403_raises(tmp_path):
+    # 404 on the state update = no loaded table -> not dropped, load proceeds
+    session = FakeSession(unload_status=404)
+    result = cas.load_fact_sheet(session, _csv(tmp_path), "llm", "Public", "cas-shared-default")
+    assert result["dropped"] is False
+    assert len(session.calls) == 3  # unload attempt, upload, save
+
+    # a permission failure must surface at the unload, not as a later 409
+    session = FakeSession(unload_status=403)
+    with pytest.raises(RuntimeError, match="Unloading LLM_FACT_SHEET"):
+        cas.load_fact_sheet(session, _csv(tmp_path), "llm", "Public", "cas-shared-default")
+    assert len(session.calls) == 1  # stopped at the unload
+
+
+def test_path_segments_are_url_encoded(tmp_path):
+    session = FakeSession()
+    cas.load_fact_sheet(session, _csv(tmp_path), "llm", "My Lib", "cas server")
+    unload_path = session.calls[0][1]
+    assert "/servers/cas%20server/caslibs/My%20Lib/tables/LLM_FACT_SHEET/state" in unload_path

--- a/Model-Definition-Builder/cli/tests/test_facts_and_import.py
+++ b/Model-Definition-Builder/cli/tests/test_facts_and_import.py
@@ -107,6 +107,12 @@ def test_rebuild_sorts_creates_and_handles_legacy(tmp_path, repo_root):
     assert read_row(sheet, "zzz_legacy_model") is None
 
 
+def test_rebuild_rejects_mixed_kinds(tmp_path, repo_root):
+    mixed = _managed_manifests(repo_root, "llm")[:1] + _managed_manifests(repo_root, "embedding")[:1]
+    with pytest.raises(ValueError, match="single kind"):
+        rebuild_sheet(tmp_path / "sheet.csv", mixed)
+
+
 LEGACY_SCORE = """import requests
 modelVersion = 'claude-3-5-sonnet-20240620'
 modelEndpoint = 'https://api.anthropic.com/v1/messages'

--- a/website/docs/Administration-Guide/Logging-&-Monitoring.md
+++ b/website/docs/Administration-Guide/Logging-&-Monitoring.md
@@ -71,9 +71,12 @@ the **SAS Environment Manager → Content → Import** page, or with the `sas-vi
 CLI `transfer` plugin:
 
 ```bash
-sas-viya transfer upload --file "LLM Usage Report.json"   # prints the package id
-sas-viya transfer import --id <package-id>
+sas-viya transfer packages upload --file "LLM Usage Report.json"   # prints the package id
+sas-viya transfer packages import --id <package-id>
 ```
+
+(On older `transfer` plugin versions the same commands are `sas-viya transfer
+upload` / `sas-viya transfer import` — they still work, marked deprecated.)
 
 The CLI must be installed with the `transfer` plugin and a signed-in profile —
 see [Introduction — SAS Viya CLI Setup](./Introduction.md#sas-viya-cli-setup).

--- a/website/docs/Administration-Guide/Model-Definition-Builder.md
+++ b/website/docs/Administration-Guide/Model-Definition-Builder.md
@@ -137,6 +137,8 @@ mdb load-facts --rebuild             # regenerate the sheets from the definition
 The CAS server defaults to `cas-shared-default` (auto-detected; override with
 `--server` or `SAS_CAS_SERVER`). This uses the casManagement REST API over the
 same session the register/publish commands use — no separate CAS connection.
+The save step writes a `.sashdat`, so target a **path-based** caslib (like
+`Public`); a database-backed caslib would reject the save.
 
 `mdb generate --all --check` verifies that every generated file matches its manifest and is intended as a CI gate. Files you edited by hand are never overwritten silently — the command tells you to either fold the change into the manifest, declare the file as hand-maintained under `generation.overrides`, or pass `--force`.
 

--- a/website/docs/Administration-Guide/Setup-Additional-UIs.md
+++ b/website/docs/Administration-Guide/Setup-Additional-UIs.md
@@ -41,25 +41,36 @@ Use the `sas-viya` command-line interface's `transfer` plugin. This assumes you 
 2. **Upload** the package — the command prints the new package's `id`:
 
    ```bash
-   sas-viya transfer upload --file SAS-Agentic-AI-Accelerator-Prompt-Builder.json
+   sas-viya transfer packages upload --file SAS-Agentic-AI-Accelerator-Prompt-Builder.json
    ```
 
 3. **Import** it by that id:
 
    ```bash
-   sas-viya transfer import --id <package-id>
+   sas-viya transfer packages import --id <package-id>
    ```
 
    Or do both in one go, capturing the id (requires [`jq`](https://jqlang.github.io/jq/)):
 
    ```bash
-   pkg=$(sas-viya --output json transfer upload \
+   pkg=$(sas-viya --output json transfer packages upload \
      --file SAS-Agentic-AI-Accelerator-Prompt-Builder.json | jq -r '.id')
-   sas-viya --output text transfer import --id "$pkg"
+   sas-viya --output text transfer packages import --id "$pkg"
    ```
 
+   (On older `transfer` plugin versions the same commands are `sas-viya transfer
+   upload` / `sas-viya transfer import` — they still work, marked deprecated.)
+
 :::note The host is a transfer substitution
-The placeholder lives in the package's `substitutions` block (the `VisualElement:ve9` value), which is exactly what SAS's import machinery is designed to remap. Editing the string before upload (step 1 above) is the simplest fix. Alternatively, generate a mapping file when you upload with `--mapping mapping.json`, set the substitution value in it, and pass the same `--mapping mapping.json` to `transfer import` — the `sas-viya` transfer plugin accepts JSON mapping files. If you do neither, the report still imports; you then correct the object's base URL in [step 5](#5-add-the-object-to-a-visual-analytics-report).
+The placeholder lives in the package's `substitutions` block (the `VisualElement:ve9` value), which is exactly what SAS's import machinery is designed to remap. Editing the string before upload (step 1 above) is the simplest fix. Alternatively, remap it at import time with a **mapping file**: pass `--mapping mapping.json` to the upload and the CLI writes a JSON file whose `substitutions` block contains the `VisualElement:ve9` entry with the placeholder URL — edit that value to your host, then pass the same file to the import:
+
+```bash
+sas-viya transfer packages upload --file SAS-Agentic-AI-Accelerator-Prompt-Builder.json --mapping mapping.json
+# edit mapping.json: replace https://your-sas-viya-host in the VisualElement:ve9 value
+sas-viya transfer packages import --id <package-id> --mapping mapping.json
+```
+
+(The mapping file also lists the package's data-table connector, so the API-key CAS table can be remapped the same way. `sas-viya transfer get-mapping --id <package-id>` regenerates the file for an already-uploaded package.) If you do neither, the report still imports; you then correct the object's base URL in [step 5](#5-add-the-object-to-a-visual-analytics-report).
 :::
 
 After import, continue at [step 3](#3-create-the-api-key-data-source) — the Job Execution definition and report already exist under **SAS Content > SAS Agentic AI Accelerator > Prompt Builder**.


### PR DESCRIPTION
## Summary

**1.8.1** — robustness follow-ups from the post-merge code review of #20, plus live validation of the transfer-package import docs. No functional changes on the happy path; all findings the review rated "should fix / worth improving" are addressed.

## Fixes

### `mdb load-facts` hardening (`viya/cas.py`)
- CAS URL path segments (server, caslib, table) are **URL-encoded** — a caslib like `"My Lib"` no longer builds a malformed request.
- An unload failure that is not "nothing loaded" (404) — e.g. a **403 permission error** — now raises immediately with a clear `Unloading … failed` message instead of surfacing later as an opaque `LOADTABLE_EXISTS` 409 on the upload.
- The save's **path-based-caslib (sashdat) assumption** is documented in code and the admin guide.

### CLI consistency (`cli.py`)
- `--prune` without `--rebuild` is now an **error (exit 2)** in both `mdb sync` and `mdb load-facts` instead of being silently ignored.
- `mdb load-facts --rebuild` gains the same `--prune` option as `mdb sync --rebuild`.
- `mdb load-facts` **exits 1** when no fact sheet was loaded (previously exit 0 with warnings).
- The duplicated rebuild loop is factored into a shared `_rebuild_sheets()` / `Context.managed_manifests()`.
- The per-table message no longer claims "created" when only the loaded copy was absent.

### `rebuild_sheet` guard (`core/facts.py`)
- Rejects a **mixed llm/embedding manifest list** instead of silently rendering one kind against the other kind's columns (the CLI never did this; the guard protects future callers).

## Import docs — validated live

The `--mapping` workflow was verified against the real CLI (**transfer plugin 1.28.27**) with a live upload round-trip of the Prompt Builder package (test package deleted afterwards; nothing imported):
- The guides now use the current **`sas-viya transfer packages upload` / `import`** form — the plugin marks the old `transfer upload` / `import` as deprecated aliases (noted for older versions).
- The mapping-file alternative is documented as verified: `upload --mapping mapping.json` writes the file containing the `VisualElement:ve9` substitution (placeholder URL) to edit; `import --mapping` applies it; `transfer get-mapping` regenerates it.

## Tests

**69 passed** (+3): unload-403 raises at the unload, 404 means not-dropped (and load proceeds), URL-encoding of path segments, mixed-kind guard. Dead `FakeSession.delete` removed. Live re-run of `mdb load-facts --caslib Public` with the encoded URLs confirmed end-to-end (both tables replaced and saved).

Also corrects the 1.8.0 CHANGELOG date and adds the 1.8.1 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
